### PR TITLE
Fixed parsing error - quotes

### DIFF
--- a/modules/audio_bookshelf.py
+++ b/modules/audio_bookshelf.py
@@ -124,7 +124,7 @@ def process_audio_books(
         results.append(output.json())
         if output.ok:
             log_file.write(
-                f"Finished Matching {item["media"]["metadata"]["title"]} using the Audible Provider"
+                f'Finished Matching {item["media"]["metadata"]["title"]} using the Audible Provider'
             )
             subprocess.run(
                 [

--- a/openaudible_to_ab.py
+++ b/openaudible_to_ab.py
@@ -158,6 +158,11 @@ def move_audio_book_files(
                 audio_book_destination_dir, audio_file_name
             )
 
+            print(f"Processing: {book_data['title']}")
+
+            log_file.write(
+                f"{datetime.now()} - INFO - Processing: {book_data['title']}\n"
+            )
             if os.path.exists(target_audio_file_path):
                 existing_file_size = os.path.getsize(target_audio_file_path)
                 downloaded_file_size = os.path.getsize(downloaded_audio_file_path)


### PR DESCRIPTION
There is a double quoted string, which contains unescaped double quotes, so it doesn't work. Changed the string double quotes to single quotes.

The second commit was supposed to be separate PR, but it ended up here.. Added log about book that is about to be processed. The same log added to console. Without this, on slower connection, it just looks like it's stuck and doing nothing. So now you at least see, directly in console, what book is it processing.

## Summary by Sourcery

Bug Fixes:
- Resolved string parsing issue with unescaped double quotes in a log message