### PR TITLE
Filter unread books

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -304,3 +304,15 @@ docs/_build/
 data/
 downloads/
 
+# Python virtual environment
+.venv/
+
+# Allow run.sh to be committed
+run.sh
+
+# Exclude GitHub files, specifically for AI-related agent configurations.
+# Will also exclude GitHub Actions by default, but those aren't in use here.
+*.github
+
+# Ignore books.json example file from OpenAudible
+books.json

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ python openaudible_to_ab.py \
 * **--download-program:** Specify the download program - OpenAudible or Libation (defaults to OpenAudible).
 * **--audio-file-extension:** Audio file extension (defaults to .m4b).
 * **--copy-instead-of-move:** Copy files instead of moving them (useful for debugging/testing). Defaults to False.
+* **--skip-audiobookshelf-sync:** Skip triggering AudioBookShelf scans and automatic matching. Use this when the destination directory is not yet visible to AudioBookShelf (for example, if files are uploaded later).
 * **--libation-folder-cleanup:** Whether to delete the source folder in Libation directory after processing (defaults to False).
 * **--libation-file-locations-path:** Path to Libation's FileLocationsV2.json file (optional, for Libation users). When provided, the script will use the exact file paths from this file instead of constructing them. This is more reliable than the legacy path construction method.
 * **--library-id:** The ID of your library in AudioBookShelf.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ python openaudible_to_ab.py \
 * **--abs-api-token:** Your AudioBookShelf API token.
 * **--books-json-path:** Path to the JSON file exported from OpenAudible or Libation containing book information. (Optional for Libation - will be auto-generated if not provided or if file doesn't exist)
 * **--purchased-how-long-ago:** Number of days to look back for recently purchased books (defaults to 7).
+* **--ignore-read-statuses:** OpenAudible only. Provide one or more read status values (e.g. `Finished`, `InProgress`) to skip copying/moving those books. Accepts multiple values or comma-separated strings.
 * **--destination-book-directory:** The destination directory where you want to organize your audiobooks.
 * **--download-program:** Specify the download program - OpenAudible or Libation (defaults to OpenAudible).
 * **--audio-file-extension:** Audio file extension (defaults to .m4b).

--- a/arguments.yaml
+++ b/arguments.yaml
@@ -18,12 +18,27 @@ destination_book_directory: ""
 audio_file_extension: ".m4b"
 copy_instead_of_move: false  # Set to true for debugging/testing
 
-# Libation-specific options
-libation_folder_cleanup: false
-libation_file_locations_path: ""  # Optional - path to Libation's FileLocationsV2.json
-
 # Processing options
 purchased_how_long_ago: 7  # Number of days to look back (0 = all books)
 
 # Logging
 log_file_path: "/tmp/book_processing.txt"
+
+# Libation-specific options
+libation_folder_cleanup: false
+libation_file_locations_path: ""  # Optional - path to Libation's FileLocationsV2.json
+
+# OpenAudible-specific options
+
+# Skip AudioBookShelf sync if the files are not yet visible to AudioBookShelf 
+# (for example, if files are uploaded later after local processing)
+skip_audiobookshelf_sync: false
+
+# Skip books with these read statuses (OpenAudible only), such as "Finished"
+# These are the possible options from OpenAudible:
+#  - Finished
+#  - Unread
+#  - Reading
+#  - Want to read
+#  - Did not finish
+ignore_read_statuses: "Finished"

--- a/modules/config.py
+++ b/modules/config.py
@@ -95,6 +95,17 @@ def _get_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
+        "--skip-audiobookshelf-sync",
+        dest="skip_audiobookshelf_sync",
+        default=False,
+        action="store_true",
+        help=(
+            "Skip triggering AudioBookShelf scans and matching. "
+            "Useful when the destination directory is not yet accessible to the server."
+        ),
+    )
+
+    parser.add_argument(
         "--libation-folder-cleanup",
         dest="libation_folder_cleanup",
         type=bool,

--- a/openaudible_to_ab.py
+++ b/openaudible_to_ab.py
@@ -297,22 +297,27 @@ def main(*args: str):
         args.ignore_read_statuses,
     )
 
-    # Now that the files have been moved, we want to kick off the AudioBookShelf scanner
-    scan_library_for_books(args.server_url, args.library_id, args.abs_api_token, log_file)
+    if not args.skip_audiobookshelf_sync:
+        # Now that the files have been moved, we want to kick off the AudioBookShelf scanner
+        scan_library_for_books(args.server_url, args.library_id, args.abs_api_token, log_file)
 
-    # We often need a back-off time in order to allow the scan to complete
-    time.sleep(15)
+        # We often need a back-off time in order to allow the scan to complete
+        time.sleep(15)
 
-    # Sometimes the scanner does not identify the books correctly
-    # In my case I buy books from audible so I want to force the match with audible content
-    books_from_audiobookshelf = get_all_books(args.server_url, args.library_id, args.abs_api_token, log_file)
-    most_recent_books = get_audio_bookshelf_recent_books(
-        books_from_audiobookshelf,
-        log_file,
-        days_ago=args.purchased_how_long_ago,
-        book_list=book_list,
-    )
-    _ = process_audio_books(most_recent_books, args.server_url, args.abs_api_token, log_file)
+        # Sometimes the scanner does not identify the books correctly
+        # In my case I buy books from audible so I want to force the match with audible content
+        books_from_audiobookshelf = get_all_books(args.server_url, args.library_id, args.abs_api_token, log_file)
+        most_recent_books = get_audio_bookshelf_recent_books(
+            books_from_audiobookshelf,
+            log_file,
+            days_ago=args.purchased_how_long_ago,
+            book_list=book_list,
+        )
+        _ = process_audio_books(most_recent_books, args.server_url, args.abs_api_token, log_file)
+    else:
+        log_file.write(
+            f"{datetime.now()} - INFO - Skipping AudioBookShelf scan and match per configuration.\n"
+        )
     log_file.close()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,7 +73,13 @@ def test_yaml_load_file_not_found(tmp_path: Path, caplog: pytest.LogCaptureFixtu
     with pytest.raises(SystemExit):
         config_obj._load_yaml()
 
-    assert caplog.record_tuples == [("modules.config", logging.CRITICAL, "YAML file not found: %s" % yamlfile)]
+    assert caplog.record_tuples == [
+        (
+            "modules.config",
+            logging.CRITICAL,
+            f"YAML file not found: {yamlfile}",
+        )
+    ]
 
 
 def test_yaml_load_invalid_file(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/test_move_audio_book_files.py
+++ b/tests/test_move_audio_book_files.py
@@ -54,6 +54,7 @@ def test_date_filtering(setup_test_environment, test_data):
         "copy_instead_of_move": False,
         "destination_dir": setup_test_environment["dest_dir"],
         "download_program": "OpenAudible",
+        "ignore_read_statuses": ["Finished"],
         "libation_folder_cleanup": False,
         "log_file": open(os.path.join(setup_test_environment["tmp_path"], "test.log"), "a"),
         "purchased_how_long_ago": 7,
@@ -65,6 +66,36 @@ def test_date_filtering(setup_test_environment, test_data):
 
     result = move_audio_book_files(**args)
     assert len(result) == 0
+
+
+def test_ignore_read_statuses_skips_books(setup_test_environment):
+    args = {
+        "audio_file_extension": ".m4b",
+        "books_json_path": os.path.join(setup_test_environment["tmp_path"], "books.json"),
+        "copy_instead_of_move": False,
+        "destination_dir": setup_test_environment["dest_dir"],
+        "download_program": "OpenAudible",
+        "ignore_read_statuses": ["finished"],
+        "libation_folder_cleanup": False,
+        "log_file": open(os.path.join(setup_test_environment["tmp_path"], "test.log"), "a"),
+        "purchased_how_long_ago": 30,
+        "source_dir": setup_test_environment["source_dir"],
+    }
+
+    book_data = {
+        "author": "Skipped Author",
+        "title": "Skipped Book",
+        "asin": "SKIP123",
+        "filename": "skip_book",
+        "purchase_date": datetime.now(timezone.utc).date().isoformat(),
+        "read_status": "Finished",
+    }
+
+    with open(args["books_json_path"], "w") as f:
+        json.dump([book_data], f)
+
+    result = move_audio_book_files(**args)
+    assert result == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Added skip files based on read_status from OpenAudible books.json from request in issue https://github.com/stratus-ss/OpenAudible-To-AudioBookShelf/issues/8 along with adding ability to skip AudioBookshelf rescan trigger in case of local processing/transfer still to happen.

Merge is clean to main but I noticed you requested a pull request to the dev branch so I re-targeted my request; looks like it needs a little cleanup against dev--sorry, didn't notice dev until after I'd made my changes and I didn't know if they would be worth contributing back up front. Up to you!

## Summary by Sourcery

Add configurable filtering, syncing, and Libation integration improvements for audiobook processing from OpenAudible/Libation into AudioBookShelf.

New Features:
- Allow skipping OpenAudible books based on their read_status field when moving files.
- Support copying files instead of moving them during processing for safer testing or local workflows.
- Add an option to skip triggering AudioBookShelf scans and matching so processing can occur independently of the server.
- Automatically generate Libation’s libation.json via libationcli when missing, removing the need for manual export.
- Use Libation’s FileLocationsV2.json when available to resolve exact audiobook file paths more reliably.

Bug Fixes:
- Fix Libation path handling for titles containing colons so destination folder and file naming match Libation’s behavior.

Enhancements:
- Return full book metadata from move_audio_book_files and improve logging around processed items and actions taken.
- Relax configuration validation to make books_json_path optional for Libation when auto-generation is possible.
- Improve argument normalization for ignore_read_statuses, supporting multiple and comma-separated values from CLI or YAML.
- Document the FileLocationsV2.json format and update README examples and arguments to reflect new options and behavior.
- Add a Makefile and VS Code launch configuration to streamline local development, testing, and code-quality workflows.

Build:
- Extend requirements.txt with development, linting, typing, and testing dependencies.

Documentation:
- Update README and example YAML to describe Libation auto-export, FileLocationsV2.json support, new CLI/YAML options, and revised usage examples.

Tests:
- Expand and adjust tests for Libation and OpenAudible flows, including date filtering, read-status skipping, FileLocationsV2.json usage, and new configuration behaviors.

Chores:
- Replace and restructure arguments.yaml to serve as a clearer, documented example configuration.